### PR TITLE
feat: change the deployment to statefulset

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @tampakrap

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Theo Chatzimichos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ client and the Spotify OAuth API.
 - [Introduction](#introduction)
 - [Prerequisities](#prerequisities)
 - [Configuration](#configuration)
+- [Usage](#usage)
 
 ## Introduction
 
@@ -61,3 +62,38 @@ the comments for more details.
 
 The `SPOTIFY_PROXY_BASE_URI` is not a secret, it can be set via a variable,
 which is named `spotifyProxyBaseURI`.
+
+Example values.yaml files:
+- [with the secrets managed by this helm chart](charts/spotify-auth-proxy/ci/ci-create-secrets-values.yaml)
+- [with external secrets](charts/spotify-auth-proxy/ci/ci-external-secrets-values.yaml)
+
+## Usage
+
+After setting up the environment variables as described above, and after
+installing the helm chart, you should have one StatefulSet with one replica
+running. Check the logs of that pod, it should output something like the
+following (replace `spotify-auth-proxy` in case you have set different name):
+
+```
+➜ kubectl -n spotify-auth-proxy logs spotify-auth-proxy-0
+APIKey:   XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Auth URL: ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+```
+
+If the `SPOTIFY_PROXY_API_KEY` is set, then the log will output only the Auth
+URL.
+
+Open the Auth URL on your browser in order to log in. In case the Auth URL is
+only accessible for localhost, then you can set a port forward:
+
+```
+➜ kubectl -n spotify-auth-proxy port-forward svc/spotify-auth-proxy 27228
+Forwarding from 127.0.0.1:27228 -> 27228
+Forwarding from [::1]:27228 -> 27228
+```
+
+Open the URL with a browser in order to login. As soon as the Authentication is
+successful, then you can use the API Key either in the [Terraform Spotify
+provider](https://github.com/conradludgate/terraform-provider-spotify) or in
+the [Crossplane Spotify
+provider](https://github.com/tampakrap/provider-spotify).

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ Environment Variable | Required/Optional | Default value
 SPOTIFY_CLIENT_ID | Required |
 SPOTIFY_CLIENT_SECRET | Required |
 SPOTIFY_PROXY_API_KEY | Optional |
-SPOTIFY_PROXY_BASE_URL | Optional | http://localhost:27228
+SPOTIFY_PROXY_BASE_URI | Optional | http://localhost:27228
 
 See the
-[README](https://github.com/conradludgate/terraform-provider-spotify/blob/main/spotify_auth_proxy/README.md) of `Spotify-Auth-Proxy` for more details on them.
+[README](https://github.com/conradludgate/terraform-provider-spotify/blob/main/spotify_auth_proxy/README.md)
+of `Spotify-Auth-Proxy` for more details on them.
 
 In the helm chart, the first three are set up via secrets, while the fourth via
 a plain text variable.
@@ -58,5 +59,5 @@ which can also be either created by the helm chart or it can be manually
 created. Search for the variable `proxyAPIKeySecret` in `values.yaml` and read
 the comments for more details.
 
-The `SPOTIFY_PROXY_BASE_URL` is not a secret, it can be set via a variable,
-which is named `spotifyProxyBaseURL`.
+The `SPOTIFY_PROXY_BASE_URI` is not a secret, it can be set via a variable,
+which is named `spotifyProxyBaseURI`.

--- a/charts/spotify-auth-proxy/Chart.yaml
+++ b/charts/spotify-auth-proxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/spotify-auth-proxy/Chart.yaml
+++ b/charts/spotify-auth-proxy/Chart.yaml
@@ -21,4 +21,5 @@ version: 0.2.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.6" # Change to 0.2.7 as soon as this ticket gets fixed https://github.com/conradludgate/terraform-provider-spotify/issues/45
+# Change to 0.2.7 as soon as this ticket gets fixed https://github.com/conradludgate/terraform-provider-spotify/issues/45
+appVersion: "0.2.6"

--- a/charts/spotify-auth-proxy/Chart.yaml
+++ b/charts/spotify-auth-proxy/Chart.yaml
@@ -23,3 +23,6 @@ version: 0.2.0
 # It is recommended to use it with quotes.
 # Change to 0.2.7 as soon as this ticket gets fixed https://github.com/conradludgate/terraform-provider-spotify/issues/45
 appVersion: "0.2.6"
+
+maintainers:
+- name: tampakrap

--- a/charts/spotify-auth-proxy/ci/ci-create-secrets-values.yaml
+++ b/charts/spotify-auth-proxy/ci/ci-create-secrets-values.yaml
@@ -1,0 +1,9 @@
+---
+clientCredentialsSecret:
+  create: true
+  spotifyClientID: test1
+  spotifyClientSecret: test2
+
+proxyAPIKeySecret:
+  create: true
+  spotifyProxyAPIKey: test3

--- a/charts/spotify-auth-proxy/ci/ci-custom-proxy-auth-url-values.yaml
+++ b/charts/spotify-auth-proxy/ci/ci-custom-proxy-auth-url-values.yaml
@@ -1,0 +1,7 @@
+---
+clientCredentialsSecret:
+  create: true
+  spotifyClientID: test1
+  spotifyClientSecret: test2
+
+spotifyProxyBaseURI: http://external.url:27228

--- a/charts/spotify-auth-proxy/ci/ci-external-secrets-values.yaml
+++ b/charts/spotify-auth-proxy/ci/ci-external-secrets-values.yaml
@@ -1,0 +1,7 @@
+---
+clientCredentialsSecret:
+  name: external-credentials
+
+proxyAPIKeySecret:
+  external: true
+  name: external-api-key

--- a/charts/spotify-auth-proxy/templates/NOTES.txt
+++ b/charts/spotify-auth-proxy/templates/NOTES.txt
@@ -15,8 +15,9 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "spotify-auth-proxy.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "spotify-auth-proxy.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  echo "Start a port-forward"
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "spotify-auth-proxy.fullname" . }} 27228
+  echo "Get the Auth URL from the pod logs"
+  kubectl --namespace {{ .Release.Namespace }} logs {{ include "spotify-auth-proxy.fullname" . }}
+  echo "Open a browser on the Auth URL to log in"
 {{- end }}

--- a/charts/spotify-auth-proxy/templates/statefulset.yaml
+++ b/charts/spotify-auth-proxy/templates/statefulset.yaml
@@ -58,9 +58,9 @@ spec:
                   name: {{ template "spotify-auth-proxy.proxyAPIKeySecretName" . }}
                   key: spotifyProxyAPIKey
             {{- end }}
-            {{- if .Values.spotifyProxyBaseURL }}
-            - name: SPOTIFY_PROXY_BASE_URL
-              value: {{ .Values.spotifyProxyBaseURL }}
+            {{- if .Values.spotifyProxyBaseURI }}
+            - name: SPOTIFY_PROXY_BASE_URI
+              value: {{ .Values.spotifyProxyBaseURI }}
             {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/charts/spotify-auth-proxy/templates/statefulset.yaml
+++ b/charts/spotify-auth-proxy/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "spotify-auth-proxy.fullname" . }}
   labels:

--- a/charts/spotify-auth-proxy/templates/tests/test-connection.yaml
+++ b/charts/spotify-auth-proxy/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "spotify-auth-proxy.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "spotify-auth-proxy.fullname" . }}:{{ .Values.service.port }}/{{ .Values.livenessProbe.httpGet.path }}']
   restartPolicy: Never

--- a/charts/spotify-auth-proxy/templates/tests/test-external-secrets.yaml
+++ b/charts/spotify-auth-proxy/templates/tests/test-external-secrets.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if not .Values.clientCredentialsSecret.create -}}
+{{- if not .Values.clientCredentialsSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,7 +15,7 @@ data:
   spotifyClientSecret: {{ "test2" | b64enc }}
 {{- end }}
 ---
-{{- if .Values.proxyAPIKeySecret.external -}}
+{{- if .Values.proxyAPIKeySecret.external }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/spotify-auth-proxy/templates/tests/test-external-secrets.yaml
+++ b/charts/spotify-auth-proxy/templates/tests/test-external-secrets.yaml
@@ -1,0 +1,31 @@
+---
+{{- if not .Values.clientCredentialsSecret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-credentials
+  labels:
+    {{- include "spotify-auth-proxy.labels" . | nindent 4 }}
+  {{- with .Values.clientCredentialsSecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  spotifyClientID: {{ "test1" | b64enc }}
+  spotifyClientSecret: {{ "test2" | b64enc }}
+{{- end }}
+---
+{{- if .Values.proxyAPIKeySecret.external -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-api-key
+  labels:
+    {{- include "spotify-auth-proxy.labels" . | nindent 4 }}
+  {{- with .Values.proxyAPIKeySecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  spotifyProxyAPIKey: {{ "test3" | b64enc }}
+{{- end }}

--- a/charts/spotify-auth-proxy/values.yaml
+++ b/charts/spotify-auth-proxy/values.yaml
@@ -22,26 +22,31 @@ clientCredentialsSecret:
   # Specifies whether the client credentials secret should be created. If set
   # to false, then a manually created secret is expected in order to set the
   # values of the environment variables described above.
-  create: true
+  create: false
   # The name of the secret. If not set, a name is generated using the fullname template.
   # If create is true, then this is the name of the secret that helm will create
   # If create is false, then this is the name of the manually created secret.
   name: ""
   # Annotations to add to the secret
   annotations: {}
-  # Required secret keys (only if "create" is "true")
-  spotifyClientID:
-  spotifyClientSecret:
+  # Required secret keys (only if "create: true")
+  # spotifyClientID:
+  # spotifyClientSecret:
 
 # (Optional) The secret that sets the SPOTIFY_PROXY_API_KEY env var.
 proxyAPIKeySecret:
+  # Specifies whether the proxy API Key secret should be created.
   create: false
+  # If external is true, then a manually created secret is expected in order to
+  # set the value of the environment variable described above.
+  # If both "create" and "external" are true, then the "external" prevails.
   external: false
   # The name of the secret. If not set, a name is generated using the fullname template.
   name: ""
   # Annotations to add to the secret
   annotations: {}
-  spotifyProxyAPIKey:
+  # Required secret key (only if "create: true" and "external: false")
+  # spotifyProxyAPIKey:
 
 # (Optional) This sets the SPOTIFY_PROXY_BASE_URL env var
 spotifyProxyBaseURL: ""

--- a/charts/spotify-auth-proxy/values.yaml
+++ b/charts/spotify-auth-proxy/values.yaml
@@ -44,7 +44,7 @@ proxyAPIKeySecret:
   spotifyProxyAPIKey:
 
 # (Optional) This sets the SPOTIFY_PROXY_BASE_URL env var
-#spotifyProxyBaseURL:
+spotifyProxyBaseURL: ""
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/spotify-auth-proxy/values.yaml
+++ b/charts/spotify-auth-proxy/values.yaml
@@ -48,8 +48,8 @@ proxyAPIKeySecret:
   # Required secret key (only if "create: true" and "external: false")
   # spotifyProxyAPIKey:
 
-# (Optional) This sets the SPOTIFY_PROXY_BASE_URL env var
-spotifyProxyBaseURL: ""
+# (Optional) This sets the SPOTIFY_PROXY_BASE_URI env var
+spotifyProxyBaseURI: ""
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
The service produces a token and an API key, which are different per
pod. The API key is configurable, the token though is not.